### PR TITLE
Changes to contribute

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM httpd:bullseye
+
+USER root
+
+COPY . /app
+
+EXPOSE 3000
+
+RUN chmod -R +x /app && apt-get update 1> ~/aptget.update.log \
+  && apt-get install git curl gcc make libpng-dev --yes -qq 1> ~/aptget.extras.log
+
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+	&& apt install nodejs
+
+WORKDIR /app
+
+RUN npm install && npm run build --webPath=""
+
+RUN rm -r /usr/local/apache2/htdocs \
+	&& cd /usr/local/apache2 \
+	&& ln -s /app/dist htdocs

--- a/build-config/webpack.prod.config.js
+++ b/build-config/webpack.prod.config.js
@@ -4,6 +4,15 @@ var path = require("path");
 const TerserPlugin = require('terser-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
+// Allow the build process to pass in the location of this app relative to the
+// web root. The default is haplotype-map-tree/. To pass in something else use
+// npm run build --webPath="/subdirectory"
+// or you can run the following if the app is installed at the web root
+// npm run build --webPath="/"
+var webpath = process.env.npm_config_webpath || 'haplotype-map-tree/';
+// Remove single leading "/" if it is present.
+if (webpath.charAt( 0 ) === '/') { webpath = webpath.substring(1); }
+
 module.exports = {
     entry: ['babel-polyfill', './src/app.jsx'],
     output: {
@@ -14,7 +23,7 @@ module.exports = {
     plugins: [new webpack.DefinePlugin({
         'process.env': {
             NODE_ENV: JSON.stringify('production'),
-            DATADIR_PATH: JSON.stringify('haplotype-map-tree/')
+            DATADIR_PATH: JSON.stringify(webpath)
         }
     }),
     new TerserPlugin({

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -96,7 +96,7 @@ class Dashboard extends Component {
             })
             .then((geneMap) => {
                 genomicData['geneMap'] = geneMap;
-                return getFile(traitPath);
+                return getFile(traitPath, 'trait');
             })
             .then((response) => {
                 var traitText = response.split('\n'),
@@ -111,14 +111,14 @@ class Dashboard extends Component {
                     });
                 genomicData['traitMap'] = traitMap;
                 genomicData['traitList'] = traitList;
-                return getFile(treeFilepath);
+                return getFile(treeFilepath, 'phylogeny');
             })
             .then((treeMap) => {
                 genomicData['treeMap'] = treeMap;
                 const { germplasmLines, genomeMap, germplasmData } = genomicData;
                 // set the genomic data
                 setGenomicData(genomicData);
-                // make a redux call to set default source and target lines 
+                // make a redux call to set default source and target lines
                 // then set the default selected chromosome as the first one
                 var newickNodes = d3v3.layout.phylotree()(genomicData['treeMap']).get_nodes();
                 var nameList = _.filter(newickNodes, (d) => d.name && d.name !== 'root').map((d) => d.name);
@@ -249,7 +249,3 @@ function mapStateToProps(state) {
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Dashboard);
-
-
-
-


### PR DESCRIPTION
Hi Venkat,

I've been working on loading our larger datasets into the haplotype-map application :-)

Here are a few contributions I have:
- edcc887: The trait and phylogeny error alerts were saying they couldn't find an undefined file ;-) This commit sets the fileType so that if any problems are encountered then that is reported to the user.
- 1b74605: This adds support to the webpack config for setting the web location of the app during build. This is backwards compatible. To specify the app is in localhost/hapmap you would run `npm run build --webPath="hapmap"`. If webPath isn't specified then it will use haplotype-map-tree (like it did before) and if the app is at the root, then you pass in "/".
- d7f159a: This adds a really simple dockerfile to play with the application (more instructions here below).

## Docker Info
It using a Debian Bullseye Docker image with apache http installed by default. The dockerfile installs Node 16, installs this application and runs the build command.

To use:
1. Create the image: `docker build ./ --tag=hapmap`
2. Create a container: 
```
docker run -dit --publish=80:80  --publish=3000:3000 --volume=`pwd`:/app --name=hapmap hapmap:latest
```
4. See the built application at http://localhost

The image supports using npm start, mounting a local copy and re-building the application.